### PR TITLE
Provide path to replace(); undefined value -> empty replacement string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *~
+*.swp
 *.bak
 .DS_Store
 npm-debug.log

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ replacer: {
       // custom configuration JSON, generate random string, etc.
       key: /{#VERSION}/g,
       value: 'v1.0.0'
+    },
+    {
+      key: 'remove_me'
+      // If value is omitted, the replacement is the empty string
     }
   ],
   // By default replacer uses String.replace() function.
@@ -42,7 +46,25 @@ replacer: {
   //  - str (string) - string to be processed
   //  - key (any) - key from the dict
   //  - value (string) - replacement value
-  replace: (str, key, value) => str.split(key).join(value)
+  //  - path (string) - the path of the file being processed
+  replace: (str, key, value, path) => str.split(key).join(value)
+}
+```
+
+For example, to replace `__filename` with the name of the file being
+processed, you can use:
+
+```js
+replacer: {
+  dict: [
+    {
+      key: /\b__filename\b/,
+      // No value needed - the custom replacer below supplies it
+    }
+  ],
+  replace: (str, key, value, path) => {
+    return str.split(key).join(`'${path}'`);
+  }
 }
 ```
 
@@ -59,3 +81,8 @@ Or, do manual install:
 ## License
 
 Licensed under [MIT License](https://github.com/tkesgar/replacer-brunch/blob/master/LICENSE).
+
+## Contributors
+
+* [Ted Kesgar](https://github.com/tkesgar)
+* [Chris White](https://github.com/cxw42)

--- a/index.js
+++ b/index.js
@@ -6,12 +6,18 @@ class BrunchReplacer {
 
     // Set defaults for config.
     if (!this.config.dict) this.config.dict = [];
-    if (!this.config.replace) this.config.replace = (str, key, value) => str.replace(key, value);
+    if (!this.config.replace) {
+      this.config.replace = (str, key, value) => str.replace(key, value);
+    }
 
     // Stringify non-string values.
     for (const entry of this.config.dict) {
       const value = entry.value;
-      entry.value = typeof value === 'string' ? value : JSON.stringify(value);
+      if (typeof value === 'undefined') {
+        entry.value = '';
+      } else {
+        entry.value = typeof value === 'string' ? value : JSON.stringify(value);
+      }
     }
   }
 
@@ -26,7 +32,7 @@ class BrunchReplacer {
     for (const entry of dict) {
       const key = entry.key;
       const value = entry.value;
-      file.data = replace(file.data, key, value);
+      file.data = replace(file.data, key, value, file.path);
     }
 
     return Promise.resolve(file);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "replacer-brunch",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Adds string replacement support to Brunch.",
   "author": "Ted Kesgar (https://tkesgar.com/)",
   "homepage": "https://github.com/tkesgar/replacer-brunch",
@@ -16,7 +16,7 @@
   "devDependencies": {
     "chai": "^3",
     "chai-as-promised": "^6.0.0",
-    "eslint": "^3.12.2",
+    "eslint": "4.x",
     "eslint-config-brunch": "brunch/eslint-config-brunch",
     "mocha": "^3"
   },

--- a/test.js
+++ b/test.js
@@ -41,9 +41,15 @@ describe('Plugin', () => {
       dict: [{key: '__KEY__', value: '__VALUE__'}],
     }}});
 
-    it('should replace key with value', () => {
+    it('should not replace when key is absent', () => {
       const file1 = {data: 'test'};
       const file2 = {data: 'test'};
+      return expect(plugin.compile(file1)).to.eventually.deep.equal(file2);
+    });
+
+    it('should replace key with value', () => {
+      const file1 = {data: '__KEY__'};
+      const file2 = {data: '__VALUE__'};
       return expect(plugin.compile(file1)).to.eventually.deep.equal(file2);
     });
 
@@ -73,6 +79,18 @@ describe('Plugin', () => {
   });
 
   describe('using non-strings as value', () => {
+
+    describe('with unspecified replacement value', () => {
+      const plugin = new Plugin({plugins: {replacer: {
+        dict: [{key: /__KEY__/g}],
+      }}});
+
+      it('should replace key with empty string', () => {
+        const file1 = {data: '__KEY__'};
+        const file2 = {data: ''};
+        return expect(plugin.compile(file1)).to.eventually.deep.equal(file2);
+      });
+    });
 
     describe('with object', () => {
       const plugin = new Plugin({plugins: {replacer: {
@@ -121,6 +139,19 @@ describe('Plugin', () => {
     it('should replace key with value', () => {
       const file1 = {data: 'The quick brown __KEY__ jumps over the lazy __KEY__'};
       const file2 = {data: 'The quick brown __VALUE__ jumps over the lazy __VALUE__'};
+      return expect(plugin.compile(file1)).to.eventually.deep.equal(file2);
+    });
+  });
+
+  describe('using custom replace function to add path', () => {
+    const plugin = new Plugin({plugins: {replacer: {
+      dict: [{key: '__KEY__', value: '__VALUE__'}],
+      replace: (str, key, value, path) => str.split(key).join(path),
+    }}});
+
+    it('should replace key with path', () => {
+      const file1 = {path: 'hello.js', data: 'The quick brown __KEY__ jumps over the lazy __KEY__'};
+      const file2 = {path: 'hello.js', data: 'The quick brown hello.js jumps over the lazy hello.js'};
       return expect(plugin.compile(file1)).to.eventually.deep.equal(file2);
     });
   });


### PR DESCRIPTION
Thanks for this plugin!  I am relatively new to brunch.  My use case is to replace `__filename` with the name of the file being processed, and this plugin and PR are the most direct way I could find to do it.  My example is in [cxw42/brunch-test](https://github.com/cxw42/brunch-test).

This PR introduces two related changes, plus documentation, tests, and cleaning to pass `eslint` checks.

 - The `file.path` parameter is given to the replacement function.
 - If no `value` key is given, the replacement string is `''` rather than the `undefined` provided by `JSON.stringify()`.  That way, if your custom replacement function is going to use the `path` argument anyway, the behaviour is well-defined even if you don't specify a replacement string. 

Note: this PR also updates the dependency on eslint from 3.x to 4.x.  This is because eslint-config-brunch@1.0.0 now requires eslint@^4.  I see that you did not check in the package-lock.json, so I also did not do so.

Thanks for considering this PR!